### PR TITLE
# PHP XML Util 6.0 - PR Description

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,1 @@
-# These are supported funding model platforms
-
 github: byjg

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "8.4"
           - "8.3"
           - "8.2"
           - "8.1"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,9 @@ on:
 jobs:
   Build:
     runs-on: 'ubuntu-latest'
-    container: 'byjg/php:${{ matrix.php-version }}-cli'
+    container:
+      image: 'byjg/php:${{ matrix.php-version }}-cli'
+      options: --user root --privileged
     strategy:
       matrix:
         php-version:
@@ -22,7 +24,7 @@ jobs:
           - "8.1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: composer install
       - run: ./vendor/bin/psalm
       - run: ./vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -34,4 +34,5 @@ jobs:
     with:
       folder: php
       project: ${{ github.event.repository.name }}
-    secrets: inherit
+    secrets:
+      DOC_TOKEN: ${{ secrets.DOC_TOKEN }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: composer install
-      - run: ./vendor/bin/phpunit --stderr
       - run: ./vendor/bin/psalm
+      - run: ./vendor/bin/phpunit
 
   Documentation:
     if: github.ref == 'refs/heads/master'

--- a/.run/Psalm.run.xml
+++ b/.run/Psalm.run.xml
@@ -1,8 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Psalm" type="PhpLocalRunConfigurationType" factoryName="PHP Console" path="$PROJECT_DIR$/vendor/bin/psalm">
-    <method v="2" />
-  </configuration>
-  <configuration default="false" name="Psalm" type="PhpLocalRunConfigurationType" factoryName="PHP Console" path="$PROJECT_DIR$/vendor/bin/psalm">
-    <method v="2" />
-  </configuration>
-</component>

--- a/.run/psalm.run.xml
+++ b/.run/psalm.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="psalm" type="ComposerRunConfigurationType" factoryName="Composer Script">
+    <option name="commandLineParameters" value="" />
+    <option name="pathToComposerJson" value="$PROJECT_DIR$/composer.json" />
+    <option name="script" value="psalm" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {  
+      "name": "Debug current Script in Console",  
+      "type": "php",  
+      "request": "launch",  
+      "program": "${file}",  
+      "cwd": "${fileDirname}",  
+      "port": 9003,  
+      "runtimeArgs": [  
+        "-dxdebug.start_with_request=yes"  
+      ],  
+      "env": {  
+        "XDEBUG_MODE": "debug,develop",  
+        "XDEBUG_CONFIG": "client_port=${port}"  
+      }  
+    },
+    {
+      "name": "PHPUnit Debug",
+      "type": "php",
+      "request": "launch",
+      "program": "${workspaceFolder}/vendor/bin/phpunit",
+      "cwd": "${workspaceFolder}",
+      "port": 9003,
+      "runtimeArgs": [
+        "-dxdebug.start_with_request=yes"
+      ],
+      "env": {
+        "XDEBUG_MODE": "debug,develop",
+        "XDEBUG_CONFIG": "client_port=${port}"
+      }
+    }
+  ]
+} 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XmlUtil
+# PHP XML Util
 
 [![Build Status](https://github.com/byjg/php-xmlutil/actions/workflows/phpunit.yml/badge.svg?branch=master)](https://github.com/byjg/php-xmlutil/actions/workflows/phpunit.yml)
 [![Opensource ByJG](https://img.shields.io/badge/opensource-byjg-success.svg)](http://opensource.byjg.com)
@@ -6,28 +6,89 @@
 [![GitHub license](https://img.shields.io/github/license/byjg/php-xmlutil.svg)](https://opensource.byjg.com/opensource/licensing.html)
 [![GitHub release](https://img.shields.io/github/release/byjg/php-xmlutil.svg)](https://github.com/byjg/php-xmlutil/releases/)
 
-A utility class to make it easy work with XML in PHP
+A powerful and intuitive PHP library for working with XML documents. This utility makes XML manipulation, querying,
+and conversion simple and straightforward in PHP.
 
-## Examples
+## Overview
 
-- [Create a new XML Document using the API](docs/using-api.md)
-- [Working with namespaces](docs/namespaces.md)
-- [Query a XMLDocument](docs/query-document.md)
-- [Convert any model to XML](docs/convert-model-xml.md)
-- [Use Attributes to help in the conversion](docs/convert-model-xml-withattributes.md)
-- [Clean an XML document removing specific tags](docs/clean-document.md)
+PHP XML Util provides a comprehensive set of tools for XML manipulation in PHP applications. It simplifies common 
+XML operations with an intuitive API, allowing developers to create, modify, query, and validate XML documents
+with minimal code.
 
-## Install
+The library is designed to be lightweight yet powerful, offering features that go beyond 
+PHP's built-in XML functionality while maintaining a clean and easy-to-use interface.
+
+## Key Features
+
+- **Simple XML Creation API** - Create and manipulate XML documents programmatically with an intuitive API
+- **XPath Querying** - Easily query and navigate XML documents using XPath expressions
+- **PHP Model ↔ XML Conversion** - Seamlessly convert between PHP objects and XML representations
+- **Attribute-Based Mapping** - Use PHP attributes to control XML serialization behavior
+- **Namespace Support** - Full support for XML namespaces in all operations
+- **Document Cleaning** - Selectively remove specific tags from XML documents
+- **XML Validation** - Validate XML documents against schemas
+- **File Handling** - Convenient methods for loading and saving XML from/to files
+
+## Quick Example
+
+```php
+<?php
+use ByJG\XmlUtil\XmlDocument;
+
+// Create a new XML document
+$xml = new XmlDocument('<root />');
+
+// Build the document structure
+$myNode = $xml->appendChild('mynode');
+$myNode->appendChild('subnode', 'text');
+$myNode->appendChild('subnode', 'more text');
+$otherNode = $myNode->appendChild('othersubnode', 'other text');
+$otherNode->addAttribute('attr', 'value');
+
+// Output formatted XML
+echo $xml->toString(format: true);
+```
+
+Output:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <mynode>
+    <subnode>text</subnode>
+    <subnode>more text</subnode>
+    <othersubnode attr="value">other text</othersubnode>
+  </mynode>
+</root>
+```
+
+## Documentation
+
+The library is fully documented with detailed guides and examples for each feature:
+
+- [Creating XML Documents](docs/using-api.md): Learn how to create and manipulate XML documents using the API
+- [Working with Namespaces](docs/namespaces.md): Guide to handling XML namespaces properly
+- [Querying with XPath](docs/query-document.md): How to use XPath expressions to query XML documents
+- [PHP Models to XML](docs/convert-model-xml.md): Converting PHP objects to XML and vice versa
+- [Attribute-Based Mapping](docs/convert-model-xml-withattributes.md): Using PHP attributes to control XML serialization
+- [Cleaning Documents](docs/clean-document.md): Removing specific tags from XML documents
+- [File Operations](docs/file-handling.md): Loading and saving XML from/to files
+- [XML Validation](docs/validate-document.md): Validating XML documents against schemas
+
+## Installation
 
 ```bash
 composer require "byjg/xmlutil"
 ```
 
-## Running the Tests
+## Running Tests
 
 ```bash
 vendor/bin/phpunit
 ```
+
+## License
+
+MIT
 
 ## Dependencies
 
@@ -37,7 +98,6 @@ flowchart TD
     byjg/xmlutil --> ext-dom
     byjg/xmlutil --> byjg/serializer
 ```
-
 
 ----
 [Open source ByJG](http://opensource.byjg.com)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# PHP XML Util
-
 [![Build Status](https://github.com/byjg/php-xmlutil/actions/workflows/phpunit.yml/badge.svg?branch=master)](https://github.com/byjg/php-xmlutil/actions/workflows/phpunit.yml)
 [![Opensource ByJG](https://img.shields.io/badge/opensource-byjg-success.svg)](http://opensource.byjg.com)
 [![GitHub source](https://img.shields.io/badge/Github-source-informational?logo=github)](https://github.com/byjg/php-xmlutil/)
 [![GitHub license](https://img.shields.io/github/license/byjg/php-xmlutil.svg)](https://opensource.byjg.com/opensource/licensing.html)
 [![GitHub release](https://img.shields.io/github/release/byjg/php-xmlutil.svg)](https://github.com/byjg/php-xmlutil/releases/)
+
+# PHP XML Util
 
 A powerful and intuitive PHP library for working with XML documents. This utility makes XML manipulation, querying,
 and conversion simple and straightforward in PHP.

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=8.1 <8.4",
+    "php": ">=8.1 <8.5",
     "ext-dom": "*",
     "ext-libxml": "*",
     "ext-simplexml": "*",
-    "byjg/serializer": "^5.0"
+    "byjg/serializer": "^5.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6",
-    "vimeo/psalm": "^5.20"
+    "phpunit/phpunit": "^9.6|^10.5|^11.5",
+    "vimeo/psalm": "^6.0"
   },
   "license": "MIT"
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "byjg/serializer": "^5.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6|^10.5|^11.5",
+    "phpunit/phpunit": "^10.5|^11.5",
     "vimeo/psalm": "^6.0"
   },
   "license": "MIT"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5|^11.5",
-    "vimeo/psalm": "^6.0"
+    "vimeo/psalm": "^5.9|^6.2"
   },
   "license": "MIT"
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ext-dom": "*",
     "ext-libxml": "*",
     "ext-simplexml": "*",
-    "byjg/serializer": "^5.1"
+    "byjg/serializer": "^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5|^11.5",

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,9 @@
     "phpunit/phpunit": "^10.5|^11.5",
     "vimeo/psalm": "^5.9|^6.2"
   },
+  "scripts": {
+    "test": "vendor/bin/phpunit",
+    "psalm": "vendor/bin/psalm"
+  },
   "license": "MIT"
 }

--- a/docs/clean-document.md
+++ b/docs/clean-document.md
@@ -4,10 +4,9 @@ sidebar_position: 6
 
 # Clean Document
 
-XmlUtil have a class for selectively remove specific marks (tags)
-from the document or remove all marks.
+XmlUtil provides a dedicated `CleanDocument` class for selectively removing specific tags or content from XML or HTML documents. This is useful for cleaning up documents before processing or display.
 
-Example:
+## Basic Usage
 
 ```php
 <?php
@@ -19,4 +18,69 @@ $document
     ->removeContentByProperty('src')
     ->stripTagsExcept(['img'])
     ->get();
+```
+
+## Available Methods
+
+### stripAllTags()
+
+Removes all HTML/XML tags from the document.
+
+```php
+$document = new \ByJG\XmlUtil\CleanDocument($html);
+$plainText = $document->stripAllTags();
+```
+
+### stripTagsExcept(array $allowedTags)
+
+Strips all HTML/XML tags except those specified in the array.
+
+```php
+$document = new \ByJG\XmlUtil\CleanDocument($html);
+$cleanHtml = $document->stripTagsExcept(['p', 'div', 'span'])->get();
+```
+
+### removeContentByProperty(string $property)
+
+Removes content from any tag that contains the specified property.
+
+```php
+$document = new \ByJG\XmlUtil\CleanDocument($html);
+// Removes all tags containing the "style" property and their content
+$cleanHtml = $document->removeContentByProperty('style')->get();
+```
+
+### removeContentByTag(string $tag, string $property = '')
+
+Removes content from the specified tag, optionally filtering by a property.
+
+```php
+$document = new \ByJG\XmlUtil\CleanDocument($html);
+// Removes all <script> tags and their content
+$cleanHtml = $document->removeContentByTag('script')->get();
+
+// Removes all <a> tags that have an "onclick" property
+$cleanHtml = $document->removeContentByTag('a', 'onclick')->get();
+```
+
+### removeContentByTagWithoutProperty(string $tag, string $property)
+
+Removes content from the specified tag that does NOT have the specified property.
+
+```php
+$document = new \ByJG\XmlUtil\CleanDocument($html);
+// Removes all <a> tags that don't have an "href" property
+$cleanHtml = $document->removeContentByTagWithoutProperty('a', 'href')->get();
+```
+
+### get()
+
+Returns the cleaned document as a string.
+
+```php
+$document = new \ByJG\XmlUtil\CleanDocument($html);
+// Apply cleaning operations
+$document->removeContentByTag('script');
+// Get the final result
+$cleanHtml = $document->get();
 ```

--- a/docs/clean-document.md
+++ b/docs/clean-document.md
@@ -8,7 +8,7 @@ XmlUtil provides a dedicated `CleanDocument` class for selectively removing spec
 
 ## Basic Usage
 
-```php
+```php title="Basic document cleaning example"
 <?php
 
 $document = new \ByJG\XmlUtil\CleanDocument($documentXmlOrHtml);
@@ -26,7 +26,7 @@ $document
 
 Removes all HTML/XML tags from the document.
 
-```php
+```php title="Removing all tags"
 $document = new \ByJG\XmlUtil\CleanDocument($html);
 $plainText = $document->stripAllTags();
 ```
@@ -35,7 +35,7 @@ $plainText = $document->stripAllTags();
 
 Strips all HTML/XML tags except those specified in the array.
 
-```php
+```php title="Keeping only specific tags"
 $document = new \ByJG\XmlUtil\CleanDocument($html);
 $cleanHtml = $document->stripTagsExcept(['p', 'div', 'span'])->get();
 ```
@@ -44,7 +44,7 @@ $cleanHtml = $document->stripTagsExcept(['p', 'div', 'span'])->get();
 
 Removes content from any tag that contains the specified property.
 
-```php
+```php title="Removing tags by property"
 $document = new \ByJG\XmlUtil\CleanDocument($html);
 // Removes all tags containing the "style" property and their content
 $cleanHtml = $document->removeContentByProperty('style')->get();
@@ -54,7 +54,7 @@ $cleanHtml = $document->removeContentByProperty('style')->get();
 
 Removes content from the specified tag, optionally filtering by a property.
 
-```php
+```php title="Removing specific tags"
 $document = new \ByJG\XmlUtil\CleanDocument($html);
 // Removes all <script> tags and their content
 $cleanHtml = $document->removeContentByTag('script')->get();
@@ -67,7 +67,7 @@ $cleanHtml = $document->removeContentByTag('a', 'onclick')->get();
 
 Removes content from the specified tag that does NOT have the specified property.
 
-```php
+```php title="Removing tags without specific property"
 $document = new \ByJG\XmlUtil\CleanDocument($html);
 // Removes all <a> tags that don't have an "href" property
 $cleanHtml = $document->removeContentByTagWithoutProperty('a', 'href')->get();
@@ -77,7 +77,7 @@ $cleanHtml = $document->removeContentByTagWithoutProperty('a', 'href')->get();
 
 Returns the cleaned document as a string.
 
-```php
+```php title="Getting the cleaned result"
 $document = new \ByJG\XmlUtil\CleanDocument($html);
 // Apply cleaning operations
 $document->removeContentByTag('script');

--- a/docs/convert-model-xml-withattributes.md
+++ b/docs/convert-model-xml-withattributes.md
@@ -11,8 +11,8 @@ Example:
 <?php
 
 use ByJG\XmlUtil\EntityParser;
-use ByJG\XmlUtil\XmlMapping\XmlEntity;
-use ByJG\XmlUtil\XmlMapping\XmlProperty;
+use ByJG\XmlUtil\Attributes\XmlEntity;
+use ByJG\XmlUtil\Attributes\XmlProperty;
 
 #[XmlEntity(
     rootElementName: 'Person',

--- a/docs/convert-model-xml-withattributes.md
+++ b/docs/convert-model-xml-withattributes.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Convert a model to XML with Attributes
 
-You can add PHP attributes to your model to help the EntityParser to convert the model to XML. 
+You can add PHP attributes to your model to help the EntityParser to convert the model to XML. This provides precise control over the XML serialization process.
 
 Example:
 ```php
@@ -67,6 +67,40 @@ The output will be:
 </Person>
 ```
 
+## Attributes as XML Attributes
+
+You can also map properties to XML attributes instead of elements:
+
+```php
+#[XmlEntity(rootElementName: 'Person', preserveCaseName: true)]
+class PersonWithAttributes
+{
+    #[XmlProperty(elementName: 'Name', preserveCaseName: true)]
+    public $name;
+    
+    #[XmlProperty(isAttribute: true)]
+    public $id;
+    
+    #[XmlProperty(isAttributeOf: 'Name')]
+    public $type;
+}
+
+$person = new PersonWithAttributes();
+$person->name = 'John Doe';
+$person->id = '12345';
+$person->type = 'full';
+
+$xml = (new EntityParser())->parse($person);
+```
+
+Output:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Person id="12345">
+  <Name type="full">John Doe</Name>
+</Person>
+```
+
 ## The XmlEntity Attribute
 
 Properties:
@@ -84,13 +118,13 @@ Properties:
 
 Properties:
 
-| Property        | Description                                                                                              | Default           |
-|-----------------|----------------------------------------------------------------------------------------------------------|-------------------|
-| `elementName`   | The name of the element different from the property name.                                                | The property name |
-| `preserveCase`  | Preserve the case of the element name, if false, all elements will be lowercase.                         | false             |
-| `namespaces`    | The namespace of the element. Need to be an associative array with prefix as key and namespace as value. | empty             |
-| `isAttribute`   | If the element is an attribute of the parent node instead of a node.                                     | false             |
-| `isAttributeOf` | The name of the sibling node that will receive the attribute.                                            | empty             |
-| `isChildOf`     | The name of the sibling node that will receive the child node.                                           | empty             |
-| `ignore`        | If true, the property will not be parsed.                                                                | false             | 
-| `ignoreEmpty`   | If true will ignore empty strings                                                                        | empty             |
+| Property           | Description                                                                                              | Default           |
+|--------------------|----------------------------------------------------------------------------------------------------------|-------------------|
+| `elementName`      | The name of the element different from the property name.                                                | The property name |
+| `preserveCaseName` | Preserve the case of the element name, if false, all elements will be lowercase.                         | false             |
+| `namespaces`       | The namespace of the element. Need to be an associative array with prefix as key and namespace as value. | empty             |
+| `isAttribute`      | If the element is an attribute of the parent node instead of a node.                                     | false             |
+| `isAttributeOf`    | The name of the sibling node that will receive the attribute.                                            | empty             |
+| `isChildOf`        | The name of the sibling node that will receive the child node.                                           | empty             |
+| `ignore`           | If true, the property will not be parsed.                                                                | false             | 
+| `ignoreEmpty`      | If true will ignore empty strings                                                                        | false             |

--- a/docs/convert-model-xml-withattributes.md
+++ b/docs/convert-model-xml-withattributes.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 You can add PHP attributes to your model to help the EntityParser to convert the model to XML. This provides precise control over the XML serialization process.
 
 Example:
-```php
+```php title="Using PHP attributes to control XML output"
 <?php
 
 use ByJG\XmlUtil\EntityParser;
@@ -23,22 +23,22 @@ class MyModel
         elementName: 'Name',
     )]
     public $name;
-    
+
     #[XmlProperty(
         elementName: 'Age',
     )]
     public $age;
-    
+
     #[XmlProperty(
         elementName: 'Year',
     )]
     private $year;
-    
+
     public function getYear()
     {
         return $this->year;
     }
-    
+
     public function setYear($year)
     {
         $this->year = $year;
@@ -71,16 +71,16 @@ The output will be:
 
 You can also map properties to XML attributes instead of elements:
 
-```php
+```php title="Mapping properties to XML attributes"
 #[XmlEntity(rootElementName: 'Person', preserveCaseName: true)]
 class PersonWithAttributes
 {
     #[XmlProperty(elementName: 'Name', preserveCaseName: true)]
     public $name;
-    
+
     #[XmlProperty(isAttribute: true)]
     public $id;
-    
+
     #[XmlProperty(isAttributeOf: 'Name')]
     public $type;
 }

--- a/docs/convert-model-xml.md
+++ b/docs/convert-model-xml.md
@@ -4,10 +4,10 @@ sidebar_position: 4
 
 # Convert a model to XML
 
-You can convert any model to XML by using the class EntityParser. 
+You can convert any model to XML by using the class EntityParser.
 
 Example:
-```php
+```php title="Converting a PHP model to XML"
 <?php
 
 use ByJG\XmlUtil\EntityParser;
@@ -17,12 +17,12 @@ class MyModel
     public $name;
     public $age;
     private $year;
-    
+
     public function getYear()
     {
         return $this->year;
     }
-    
+
     public function setYear($year)
     {
         $this->year = $year;
@@ -56,7 +56,7 @@ The output will be:
 You can add an object to the XML using the API.
 
 Example:
-```php
+```php title="Adding an object to an XML node"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 

--- a/docs/file-handling.md
+++ b/docs/file-handling.md
@@ -28,8 +28,11 @@ use ByJG\XmlUtil\XmlDocument;
 
 $file = new File('/path/to/file.xml');
 
-// Get the file contents
+// Get the file contents (returns string|bool)
 $contents = $file->getContents();
+if ($contents === false) {
+    // Handle error
+}
 
 // Create an XmlDocument from the file
 $xml = new XmlDocument($file);

--- a/docs/file-handling.md
+++ b/docs/file-handling.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 7
+---
+
+# File Handling
+
+XmlUtil provides a simple File class for handling XML files.
+
+## Creating a File instance
+
+```php
+<?php
+use ByJG\XmlUtil\File;
+
+// Create a File instance for an existing file
+$file = new File('/path/to/file.xml');
+
+// Create a File instance for a new file (that doesn't exist yet)
+$file = new File('/path/to/newfile.xml', true);
+```
+
+## Reading a file
+
+```php
+<?php
+use ByJG\XmlUtil\File;
+use ByJG\XmlUtil\XmlDocument;
+
+$file = new File('/path/to/file.xml');
+
+// Get the file contents
+$contents = $file->getContents();
+
+// Create an XmlDocument from the file
+$xml = new XmlDocument($file);
+```
+
+## Saving a file
+
+```php
+<?php
+use ByJG\XmlUtil\File;
+use ByJG\XmlUtil\XmlDocument;
+
+// Save XML to a file
+$xml = new XmlDocument('<root><node>value</node></root>');
+$xml->save('/path/to/file.xml');
+
+// Or use the File class directly
+$file = new File('/path/to/file.xml', true);
+$file->save($xml->toString());
+```
+
+## Getting the filename
+
+```php
+<?php
+use ByJG\XmlUtil\File;
+
+$file = new File('/path/to/file.xml');
+$filename = $file->getFilename();
+``` 

--- a/docs/file-handling.md
+++ b/docs/file-handling.md
@@ -8,7 +8,7 @@ XmlUtil provides a simple File class for handling XML files.
 
 ## Creating a File instance
 
-```php
+```php title="Creating File instances"
 <?php
 use ByJG\XmlUtil\File;
 
@@ -21,7 +21,7 @@ $file = new File('/path/to/newfile.xml', true);
 
 ## Reading a file
 
-```php
+```php title="Reading XML from file"
 <?php
 use ByJG\XmlUtil\File;
 use ByJG\XmlUtil\XmlDocument;
@@ -40,7 +40,7 @@ $xml = new XmlDocument($file);
 
 ## Saving a file
 
-```php
+```php title="Saving XML to file"
 <?php
 use ByJG\XmlUtil\File;
 use ByJG\XmlUtil\XmlDocument;
@@ -56,7 +56,7 @@ $file->save($xml->toString());
 
 ## Getting the filename
 
-```php
+```php title="Getting the filename"
 <?php
 use ByJG\XmlUtil\File;
 

--- a/docs/namespaces.md
+++ b/docs/namespaces.md
@@ -2,11 +2,11 @@
 sidebar_position: 2
 ---
 
-# Working with xml namespaces
+# Working with XML Namespaces
 
 Add a namespace to the document
 
-```php
+```php title="Adding a namespace"
 $xml->addNamespace('my', 'http://www.example.com/mytest/');
 ```
 
@@ -14,19 +14,19 @@ will produce
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<root xmlns:my="http://www.example.com/mytest/"> 
+<root xmlns:my="http://www.example.com/mytest/">
     ...
 </root>
-``````
+```
 
 Add a node with a namespace prefix
 
-```php
+```php title="Adding node with namespace prefix"
 $xml->appendChild('my:othernodens', 'teste');
 ```
 
 Add a node with a namespace
 
-```php
+```php title="Adding node with namespace URI"
 $xml->appendChild('nodens', 'teste', 'http://www.example.com/mytest/');
 ```

--- a/docs/query-document.md
+++ b/docs/query-document.md
@@ -13,5 +13,5 @@ $node = $xml->selectSingleNode('//subnode');
 ## Select all nodes based on XPath
 
 ```php
-$nodeList = $xml->selectNodes($myNode, '//subnode');
+$nodeList = $xml->selectNodes('//subnode');
 ```

--- a/docs/query-document.md
+++ b/docs/query-document.md
@@ -4,6 +4,8 @@ sidebar_position: 3
 
 # Querying a Document
 
+XmlUtil provides powerful XPath functionality to query XML documents.
+
 ## Select a single node based on XPath
 
 ```php
@@ -14,4 +16,74 @@ $node = $xml->selectSingleNode('//subnode');
 
 ```php
 $nodeList = $xml->selectNodes('//subnode');
+
+// Iterate through the results
+foreach ($nodeList as $node) {
+    // Create an XmlNode instance from each DOMNode
+    $xmlNode = new \ByJG\XmlUtil\XmlNode($node);
+    
+    // Now you can use all XmlNode methods
+    echo $xmlNode->innerText();
+}
+```
+
+## Working with namespaces in XPath queries
+
+If your XML document uses namespaces, you can include them in your XPath queries:
+
+```php
+// Create a namespace array
+$namespaces = [
+    'ns1' => 'http://www.example.com/namespace1',
+    'ns2' => 'http://www.example.com/namespace2'
+];
+
+// Query using namespaces
+$node = $xml->selectSingleNode('//ns1:element', $namespaces);
+$nodeList = $xml->selectNodes('//ns2:element', $namespaces);
+```
+
+## Working with selected nodes
+
+After selecting a node, you can manipulate it using all XmlNode methods:
+
+```php
+// Get a node
+$node = $xml->selectSingleNode('//element');
+
+// Get text content
+$text = $node->innerText();
+
+// Add a child node to the selected node
+$node->appendChild('child', 'text content');
+
+// Add an attribute
+$node->addAttribute('name', 'value');
+
+// Convert the node to array
+$array = $node->toArray();
+
+// Remove the node
+$node->removeNode();
+
+// Rename the node
+$node->renameNode('newName');
+```
+
+## Complex queries
+
+You can create more complex XPath queries:
+
+```php
+// Find all elements with a specific attribute
+$nodes = $xml->selectNodes('//element[@attr="value"]');
+
+// Find elements with specific text
+$nodes = $xml->selectNodes('//element[text()="specific text"]');
+
+// Find the first child element
+$node = $xml->selectSingleNode('./child::*[1]');
+
+// Combine conditions
+$nodes = $xml->selectNodes('//element[@attr1="value1" and @attr2="value2"]');
 ```

--- a/docs/query-document.md
+++ b/docs/query-document.md
@@ -8,20 +8,20 @@ XmlUtil provides powerful XPath functionality to query XML documents.
 
 ## Select a single node based on XPath
 
-```php
+```php title="Selecting a single node with XPath"
 $node = $xml->selectSingleNode('//subnode');
 ```
 
 ## Select all nodes based on XPath
 
-```php
+```php title="Selecting multiple nodes with XPath"
 $nodeList = $xml->selectNodes('//subnode');
 
 // Iterate through the results
 foreach ($nodeList as $node) {
     // Create an XmlNode instance from each DOMNode
     $xmlNode = new \ByJG\XmlUtil\XmlNode($node);
-    
+
     // Now you can use all XmlNode methods
     echo $xmlNode->innerText();
 }
@@ -31,7 +31,7 @@ foreach ($nodeList as $node) {
 
 If your XML document uses namespaces, you can include them in your XPath queries:
 
-```php
+```php title="XPath queries with namespaces"
 // Create a namespace array
 $namespaces = [
     'ns1' => 'http://www.example.com/namespace1',
@@ -47,7 +47,7 @@ $nodeList = $xml->selectNodes('//ns2:element', $namespaces);
 
 After selecting a node, you can manipulate it using all XmlNode methods:
 
-```php
+```php title="Manipulating selected nodes"
 // Get a node
 $node = $xml->selectSingleNode('//element');
 
@@ -74,7 +74,7 @@ $node->renameNode('newName');
 
 You can create more complex XPath queries:
 
-```php
+```php title="Complex XPath examples"
 // Find all elements with a specific attribute
 $nodes = $xml->selectNodes('//element[@attr="value"]');
 

--- a/docs/using-api.md
+++ b/docs/using-api.md
@@ -4,7 +4,46 @@ sidebar_position: 1
 
 # Using the API
 
-## Example
+The XmlUtil library provides a simple but powerful API for working with XML documents. Here's how to get started.
+
+## Creating XML Documents
+
+### From a string
+
+```php
+<?php
+use ByJG\XmlUtil\XmlDocument;
+
+// Create from an XML string
+$xml = new XmlDocument('<root />');
+```
+
+### From a file
+
+```php
+<?php
+use ByJG\XmlUtil\XmlDocument;
+use ByJG\XmlUtil\File;
+
+// Create from a file
+$file = new File('/path/to/file.xml');
+$xml = new XmlDocument($file);
+```
+
+### Create an empty document
+
+```php
+<?php
+use ByJG\XmlUtil\XmlDocument;
+
+// Create an empty document with a specific root element
+$xml = XmlDocument::emptyDocument('root');
+
+// Create with a namespace
+$xml = XmlDocument::emptyDocument('root', 'http://www.example.com/ns');
+```
+
+## Building XML Structure
 
 ```php
 <?php
@@ -12,16 +51,20 @@ use ByJG\XmlUtil\XmlDocument;
 
 $xml = new XmlDocument('<root />');
 
+// Add child nodes
 $myNode = $xml->appendChild('mynode');
 $myNode->appendChild('subnode', 'text');
 $myNode->appendChild('subnode', 'more text');
 $otherNode = $myNode->appendChild('othersubnode', 'other text');
+
+// Add attributes
 $otherNode->addAttribute('attr', 'value');
 
+// Output formatted XML
 echo $xml->toString(format: true);
 ```
 
-will produce the follow xml
+Output:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -34,20 +77,112 @@ will produce the follow xml
 </root>
 ```
 
-## Convert to array
+## Working with Nodes
+
+### Adding Text
+
+```php
+$node = $xml->appendChild('node');
+$node->addText('Some text');
+
+// Add CDATA section
+$node->addText('This is <CDATA> content', true);
+```
+
+### Inserting Nodes
+
+```php
+// Insert a node before the current node
+$newNode = $node->insertBefore('newnode', 'new node text');
+```
+
+### Getting the Parent Node
+
+```php
+$parent = $node->parentNode();
+```
+
+### Renaming Nodes
+
+```php
+// Rename the current node
+$node->renameNode('newName');
+
+// Rename with namespace prefix
+$node->renameNode('prefix:newName');
+```
+
+### Removing Nodes
+
+```php
+// Remove the current node
+$node->removeNode();
+
+// Remove all nodes with a specific tag name
+$xml->removeTagName('tagToRemove');
+```
+
+### Adding objects
+
+```php
+// Add a PHP object or array to the XML structure
+$object = new stdClass();
+$object->property = 'value';
+$node->appendObject($object);
+```
+
+### Importing nodes from another document
+
+```php
+// Import nodes from another document or file
+$node->importNodes($otherXmlNode, 'nodeToImport');
+```
+
+## Converting to Other Formats
+
+### Convert to Array
 
 ```php
 $array = $xml->toArray();
 ```
 
-## Convert to String
+### Convert to String
 
 ```php
-$array = $xml->toString();
+// Default output
+$string = $xml->toString();
+
+// Formatted output
+$string = $xml->toString(format: true);
+
+// Without XML header
+$string = $xml->toString(noHeader: true);
 ```
 
+## Accessing DOM Objects
 
-## Diagram
+```php
+// Get the underlying DOMNode
+$domNode = $xml->DOMNode();
+
+// Get the underlying DOMDocument
+$domDocument = $xml->DOMDocument();
+```
+
+## Saving XML
+
+```php
+// Save to a file
+$xml->save('/path/to/output.xml');
+
+// Save with formatting
+$xml->save('/path/to/output.xml', format: true);
+
+// Save without XML header
+$xml->save('/path/to/output.xml', format: true, noHeader: true);
+```
+
+## Class Diagram
 
 ```mermaid
 classDiagram
@@ -66,13 +201,13 @@ classDiagram
         toArray()
         addNamespace()
         importNodes()
+        renameNode()
         DOMNode()
         DOMDocument()
         toString()
     }
     class XmlDocument{
         save()
-        getRootNode()
+        validate()
     }
-
 ```

--- a/docs/using-api.md
+++ b/docs/using-api.md
@@ -10,7 +10,7 @@ The XmlUtil library provides a simple but powerful API for working with XML docu
 
 ### From a string
 
-```php
+```php title="Creating from an XML string"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 
@@ -20,7 +20,7 @@ $xml = new XmlDocument('<root />');
 
 ### From a file
 
-```php
+```php title="Creating from a file"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 use ByJG\XmlUtil\File;
@@ -32,7 +32,7 @@ $xml = new XmlDocument($file);
 
 ### Create an empty document
 
-```php
+```php title="Creating an empty document"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 
@@ -45,7 +45,7 @@ $xml = XmlDocument::emptyDocument('root', 'http://www.example.com/ns');
 
 ## Building XML Structure
 
-```php
+```php title="Building XML structure programmatically"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 
@@ -66,7 +66,7 @@ echo $xml->toString(format: true);
 
 Output:
 
-```xml
+```xml title="Resulting XML"
 <?xml version="1.0" encoding="utf-8"?>
 <root>
   <mynode>
@@ -81,7 +81,7 @@ Output:
 
 ### Adding Text
 
-```php
+```php title="Adding text and CDATA"
 $node = $xml->appendChild('node');
 $node->addText('Some text');
 
@@ -91,20 +91,20 @@ $node->addText('This is <CDATA> content', true);
 
 ### Inserting Nodes
 
-```php
+```php title="Inserting nodes before the current node"
 // Insert a node before the current node
 $newNode = $node->insertBefore('newnode', 'new node text');
 ```
 
 ### Getting the Parent Node
 
-```php
+```php title="Getting the parent node"
 $parent = $node->parentNode();
 ```
 
 ### Renaming Nodes
 
-```php
+```php title="Renaming nodes"
 // Rename the current node
 $node->renameNode('newName');
 
@@ -114,7 +114,7 @@ $node->renameNode('prefix:newName');
 
 ### Removing Nodes
 
-```php
+```php title="Removing nodes"
 // Remove the current node
 $node->removeNode();
 
@@ -124,7 +124,7 @@ $xml->removeTagName('tagToRemove');
 
 ### Adding objects
 
-```php
+```php title="Adding PHP objects to XML"
 // Add a PHP object or array to the XML structure
 $object = new stdClass();
 $object->property = 'value';
@@ -133,7 +133,7 @@ $node->appendObject($object);
 
 ### Importing nodes from another document
 
-```php
+```php title="Importing nodes from another document"
 // Import nodes from another document or file
 $node->importNodes($otherXmlNode, 'nodeToImport');
 ```
@@ -142,13 +142,13 @@ $node->importNodes($otherXmlNode, 'nodeToImport');
 
 ### Convert to Array
 
-```php
+```php title="Converting XML to array"
 $array = $xml->toArray();
 ```
 
 ### Convert to String
 
-```php
+```php title="Converting XML to string"
 // Default output
 $string = $xml->toString();
 
@@ -161,7 +161,7 @@ $string = $xml->toString(noHeader: true);
 
 ## Accessing DOM Objects
 
-```php
+```php title="Accessing underlying DOM objects"
 // Get the underlying DOMNode
 $domNode = $xml->DOMNode();
 
@@ -171,7 +171,7 @@ $domDocument = $xml->DOMDocument();
 
 ## Saving XML
 
-```php
+```php title="Saving XML to file"
 // Save to a file
 $xml->save('/path/to/output.xml');
 

--- a/docs/validate-document.md
+++ b/docs/validate-document.md
@@ -1,0 +1,45 @@
+---
+sidebar_position: 8
+---
+
+# Validating XML Documents
+
+XmlUtil provides a way to validate XML documents against XSD schemas.
+
+## Validating an XML document
+
+```php
+<?php
+use ByJG\XmlUtil\XmlDocument;
+
+$xml = new XmlDocument('<root><node>value</node></root>');
+
+// Validate against an XSD schema
+try {
+    $xml->validate('/path/to/schema.xsd');
+    echo "Document is valid!";
+} catch (\ByJG\XmlUtil\Exception\XmlUtilException $e) {
+    echo "Document is not valid: " . $e->getMessage();
+}
+```
+
+## Getting validation errors without throwing exceptions
+
+```php
+<?php
+use ByJG\XmlUtil\XmlDocument;
+
+$xml = new XmlDocument('<root><node>value</node></root>');
+
+// Validate and get errors without throwing an exception
+$errors = $xml->validate('/path/to/schema.xsd', false);
+
+if (empty($errors)) {
+    echo "Document is valid!";
+} else {
+    echo "Document is not valid:";
+    foreach ($errors as $error) {
+        echo "- " . $error . "\n";
+    }
+}
+``` 

--- a/docs/validate-document.md
+++ b/docs/validate-document.md
@@ -8,7 +8,7 @@ XmlUtil provides a way to validate XML documents against XSD schemas.
 
 ## Validating an XML document
 
-```php
+```php title="Validating against XSD schema"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 
@@ -25,7 +25,7 @@ try {
 
 ## Getting validation errors without throwing exceptions
 
-```php
+```php title="Getting validation errors"
 <?php
 use ByJG\XmlUtil\XmlDocument;
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,7 @@ and open the template in the editor.
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnPhpunitDeprecations="true"
          stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
   <php>
     <ini name="display_errors" value="On"/>
     <ini name="display_startup_errors" value="On"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,24 +9,24 @@ and open the template in the editor.
          bootstrap="./vendor/autoload.php"
          colors="true"
          testdox="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnPhpunitDeprecations="true"
          stopOnFailure="false"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-
   <php>
     <ini name="display_errors" value="On"/>
     <ini name="display_startup_errors" value="On"/>
     <ini name="error_reporting" value="E_ALL"/>
   </php>
 
-  <coverage>
+  <source>
     <include>
-      <directory>./src</directory>
+      <directory>./src/</directory>
     </include>
-  </coverage>
+  </source>
 
   <testsuites>
     <testsuite name="Test Suite">

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
     resolveFromConfigFile="true"
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
+    cacheDirectory="/tmp/psalm"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Attributes/XmlEntity.php
+++ b/src/Attributes/XmlEntity.php
@@ -17,7 +17,7 @@ class XmlEntity
     private ?string $usePrefix;
     private bool $explicityMap = false;
 
-    public function __construct(?string $rootElementName = null, array $namespaces = [], bool $preserveCaseName = false, bool $addNamespaceRoot = true, string $usePrefix = null, bool $explicityMap = false)
+    public function __construct(?string $rootElementName = null, array $namespaces = [], bool $preserveCaseName = false, bool $addNamespaceRoot = true, ?string $usePrefix = null, bool $explicityMap = false)
     {
         $this->rootElementName = $rootElementName;
         $this->namespaces = $namespaces;

--- a/src/EntityParser.php
+++ b/src/EntityParser.php
@@ -105,7 +105,7 @@ class EntityParser
      * @throws DOMException
      * @throws XmlUtilException
      */
-    public function arrayToXml(object|array $array, XmlNode $xml, XmlEntity $rootMetadata = null): void
+    public function arrayToXml(object|array $array, XmlNode $xml, ?XmlEntity $rootMetadata = null): void
     {
         // The main Root document is not empty
         if (empty($rootMetadata)) {

--- a/src/EntityParser.php
+++ b/src/EntityParser.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * This file contains the EntityParser class for converting PHP objects and arrays to XML.
+ * 
+ * @package ByJG\XmlUtil
+ * @author Joao Gilberto Magalhaes
+ * @copyright Copyright (c) 2023 ByJG
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace ByJG\XmlUtil;
 
@@ -12,6 +20,12 @@ use ReflectionAttribute;
 use ReflectionClass;
 use stdClass;
 
+/**
+ * Class for converting PHP objects and arrays to XML.
+ * 
+ * This class provides methods to transform PHP objects and arrays into XML structures,
+ * respecting property attributes and metadata for customizing the XML output.
+ */
 class EntityParser
 {
     protected array $properties = [];
@@ -99,15 +113,17 @@ class EntityParser
     }
 
     /**
-     * @param object|array $array $array
-     * @param XmlNode $xml
-     * @param XmlEntity|null $rootMetadata
+     * Converts an array or object to XML nodes
+     * 
+     * @param object|array $array The data to convert to XML
+     * @param XmlNode $xml The XML node to append data to
+     * @param XmlEntity|null $rootMetadata Metadata for the root element
      * @throws DOMException
      * @throws XmlUtilException
      */
     public function arrayToXml(object|array $array, XmlNode $xml, ?XmlEntity $rootMetadata = null): void
     {
-        // The main Root document is not empty
+        // Initialize root metadata if not provided
         if (empty($rootMetadata)) {
             $rootMetadata = $this->getReflectionClassMeta($array);
             if (empty($rootMetadata)) {
@@ -116,77 +132,225 @@ class EntityParser
             $this->addNamespaces($xml, $rootMetadata);
         }
 
+        // Handle anonymous classes as a special case
+        if (is_object($array) && (new ReflectionClass($array))->isAnonymous()) {
+            $this->processAnonymousClass($array, $xml, $rootMetadata);
+            return;
+        }
+
+        // Define property transformer function
         $transformer = function (?XmlProperty $property, $parsedValue, $propertyName) use ($xml, $rootMetadata) {
-            $name = $property?->getElementName() ?? $propertyName;
-            $name = (($property?->getPreserveCaseName() ?? false) || $rootMetadata->getPreserveCaseNameChild()) ? $name : strtolower($name);
-            $isAttribute = $property?->isAttribute();
-            $isAttributeOf = $property?->getIsAttributeOf();
-            $hasAttribute = !is_null($property?->getElementName());
-            $childOf = $property?->getChildOf();
-
-            if ($property?->getIgnore() ?? false) {
-                return false;
-            }
-            if ($property?->getIgnoreEmpty() ?? false) {
-                if (!is_numeric($parsedValue)) {
-                    if (is_string($parsedValue)) {
-                        $parsedValue = trim($parsedValue);
-                    }
-
-                    if (empty($parsedValue)) {
-                        return false;
-                    }
-                }
-            }
-            if (!$hasAttribute && $this->explicityMap) {
+            // Skip processing if needed
+            if ($this->shouldSkipProperty($property, $parsedValue)) {
                 return false;
             }
 
-            return $this->processArray($parsedValue, $propertyName, $name, $xml)
-                || $this->processObject($parsedValue, $name, $childOf, $xml)
-                || $this->processScalar($parsedValue, $rootMetadata, $isAttribute, $isAttributeOf, $name, $childOf, $xml);
+            // Get normalized property name
+            $name = $this->getNormalizedPropertyName($property, $propertyName, $rootMetadata);
+            
+            // Process the value based on its type
+            return $this->processPropertyValue(
+                $parsedValue, 
+                $propertyName, 
+                $name, 
+                $xml, 
+                $rootMetadata, 
+                $property
+            );
         };
 
+        // Process object/array properties
         Serialize::from($array)
             ->withStopAtFirstLevel()
-            ->parseAttributes(
-                $transformer,
-                XmlProperty::class
-            );
+            ->parseAttributes($transformer, XmlProperty::class);
     }
 
+    /**
+     * Determine if a property should be skipped during XML conversion
+     * 
+     * @param XmlProperty|null $property
+     * @param mixed $parsedValue
+     * @return bool
+     */
+    private function shouldSkipProperty(?XmlProperty $property, $parsedValue): bool
+    {
+        // Skip if explicitly ignored
+        if ($property?->getIgnore() ?? false) {
+            return true;
+        }
+        
+        // Skip empty values if ignoreEmpty is set
+        if ($property?->getIgnoreEmpty() ?? false) {
+            if (!is_numeric($parsedValue)) {
+                if (is_string($parsedValue)) {
+                    $parsedValue = trim($parsedValue);
+                }
+
+                if (empty($parsedValue)) {
+                    return true;
+                }
+            }
+        }
+        
+        // Skip if explicity mapping is required but no attribute name is set
+        if (!($property?->getElementName()) && $this->explicityMap) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Get the normalized property name for XML conversion
+     * 
+     * @param XmlProperty|null $property
+     * @param string $propertyName
+     * @param XmlEntity $rootMetadata
+     * @return string
+     */
+    private function getNormalizedPropertyName(?XmlProperty $property, string $propertyName, XmlEntity $rootMetadata): string
+    {
+        $name = $property?->getElementName() ?? $propertyName;
+        $preserveCase = ($property?->getPreserveCaseName() ?? false) || $rootMetadata->getPreserveCaseNameChild();
+        
+        return $preserveCase ? $name : strtolower($name);
+    }
+    
+    /**
+     * Process a property value and add it to the XML structure
+     * 
+     * @param mixed $parsedValue
+     * @param string $propertyName
+     * @param string $name
+     * @param XmlNode $xml
+     * @param XmlEntity $rootMetadata
+     * @param XmlProperty|null $property
+     * @return bool
+     * @throws DOMException
+     * @throws XmlUtilException
+     */
+    private function processPropertyValue(
+        mixed $parsedValue, 
+        string $propertyName, 
+        string $name, 
+        XmlNode $xml, 
+        XmlEntity $rootMetadata, 
+        ?XmlProperty $property
+    ): bool {
+        $isAttribute = $property?->isAttribute();
+        $isAttributeOf = $property?->getIsAttributeOf();
+        $childOf = $property?->getChildOf();
+        
+        // Process value based on its type
+        return $this->processArray($parsedValue, $propertyName, $name, $xml)
+            || $this->processObject($parsedValue, $name, $childOf, $xml)
+            || $this->processScalar($parsedValue, $rootMetadata, $isAttribute, $isAttributeOf, $name, $childOf, $xml);
+    }
+
+    /**
+     * Process an anonymous class and extract its properties using getters
+     *
+     * @param object $anonymousClass
+     * @param XmlNode $xml
+     * @param XmlEntity $rootMetadata
+     * @throws DOMException
+     * @throws XmlUtilException
+     */
+    private function processAnonymousClass(object $anonymousClass, XmlNode $xml, XmlEntity $rootMetadata): void
+    {
+        // Get all methods to find getters
+        $methods = get_class_methods($anonymousClass);
+        
+        foreach ($methods as $method) {
+            // Only process getter methods
+            if (str_starts_with($method, 'get') && strlen($method) > 3) {
+                $propertyName = lcfirst(substr($method, 3));
+                $value = $anonymousClass->$method();
+                
+                // Skip null values
+                if ($value !== null) {
+                    // Add property values directly to XML nodes
+                    $this->processScalar($value, $rootMetadata, false, null, $propertyName, null, $xml);
+                }
+            }
+        }
+    }
+
+    /**
+     * Process an array value and convert it to XML structure
+     * 
+     * @param mixed $parsedValue The array to process
+     * @param string $propertyName The property name
+     * @param string $name The XML node name
+     * @param XmlNode $xml The parent XML node
+     * @return bool Whether the value was processed
+     * @throws DOMException
+     * @throws XmlUtilException
+     */
     protected function processArray(mixed $parsedValue, string $propertyName, string $name, XmlNode $xml): bool
     {
+        // Only process array values
         if (!is_array($parsedValue)) {
             return false;
         }
-        if (!is_numeric($propertyName)) {
-            $subnode = $xml->appendChild("$name");
-        } else {
-            $subnode = $xml;
-        }
+        
+        // Create container node for array values if needed
+        $subnode = is_numeric($propertyName) ? $xml : $xml->appendChild("$name");
         $createAgain = false;
+        
         foreach ($parsedValue as $key => $value) {
-            if (is_scalar($value) && !is_numeric($key)) {
-                $subnode->appendChild($key, htmlspecialchars("$value"));
-            } elseif (is_scalar($value) && is_numeric($key)) {
-                if ($createAgain) {
-                    $subnode = $subnode->parentNode()->appendChild($subnode->DOMNode()->nodeName);
-                }
-                $subnode->addText(htmlspecialchars("$value"));
-                $createAgain = true;
+            if (is_scalar($value)) {
+                $this->processScalarArrayItem($key, $value, $subnode, $createAgain);
+                // Update flag for consecutive scalar values with numeric keys
+                $createAgain = is_numeric($key);
             } elseif (is_array($value)) {
                 $this->processArray($value, $key, $key, $subnode);
             } else {
+                // Handle objects in array
                 $metadata = $this->getReflectionClassMeta($value);
                 $subnodeArray = $subnode->appendChild("{$metadata->getRootElementName()}");
                 $this->arrayToXml($value, $subnodeArray);
             }
         }
+        
         return true;
     }
 
     /**
+     * Process a scalar value within an array
+     *
+     * @param mixed $key Array key
+     * @param mixed $value Array value
+     * @param XmlNode $subnode Parent XML node
+     * @param bool $createAgain Whether to create a new node
+     * @return void
+     * @throws DOMException
+     * @throws XmlUtilException
+     */
+    private function processScalarArrayItem(mixed $key, mixed $value, XmlNode $subnode, bool &$createAgain): void
+    {
+        $safeValue = htmlspecialchars("$value");
+        
+        if (!is_numeric($key)) {
+            // For associative arrays, create key-named elements
+            $subnode->appendChild($key, $safeValue);
+        } else {
+            // For numeric keys, add content to parent or create new element
+            if ($createAgain) {
+                $subnode = $subnode->parentNode()->appendChild($subnode->DOMNode()->nodeName);
+            }
+            $subnode->addText($safeValue);
+        }
+    }
+
+    /**
+     * Process an object value and convert it to XML
+     *
+     * @param mixed $parsedValue The object to process
+     * @param string $name The XML node name
+     * @param string|null $childOf Parent node selector if it should be a child of another element
+     * @param XmlNode $xml The parent XML node
+     * @return bool Whether the value was processed
      * @throws XmlUtilException
      * @throws DOMException
      */
@@ -196,29 +360,55 @@ class EntityParser
             return false;
         }
 
-        if (!empty($childOf)) {
-            $subnode = $xml->selectSingleNode($childOf)->appendChild($name);
-        } else {
-            $subnode = $xml->appendChild($name);
-        }
+        // Determine the parent node based on childOf attribute
+        $parentNode = !empty($childOf) ? $xml->selectSingleNode($childOf) : $xml;
+        
+        // Create and populate the node
+        $subnode = $parentNode->appendChild($name);
         $this->arrayToXml($parsedValue, $subnode);
 
         return true;
     }
 
-    protected function processScalar(mixed $parsedValue, XmlEntity $rootMetadata, ?bool $isAttribute, ?string $isAttributeOf, string $name, ?string $isChildOf, XmlNode $xml): bool
-    {
+    /**
+     * Process a scalar value and add it to XML
+     *
+     * @param mixed $parsedValue The scalar value to process
+     * @param XmlEntity $rootMetadata Root element metadata
+     * @param bool|null $isAttribute Whether the value should be an attribute
+     * @param string|null $isAttributeOf Parent node selector if it should be an attribute of another element
+     * @param string $name The XML node name or attribute name
+     * @param string|null $isChildOf Parent node selector if it should be a child of another element
+     * @param XmlNode $xml The parent XML node
+     * @return bool Always returns true
+     * @throws DOMException
+     * @throws XmlUtilException
+     */
+    protected function processScalar(
+        mixed $parsedValue, 
+        XmlEntity $rootMetadata, 
+        ?bool $isAttribute, 
+        ?string $isAttributeOf, 
+        string $name, 
+        ?string $isChildOf, 
+        XmlNode $xml
+    ): bool {
+        $safeValue = htmlspecialchars("$parsedValue");
+        
         if ($isAttribute === true) {
-            $xml->addAttribute($name, htmlspecialchars("$parsedValue"));
-        } else if (!empty($isChildOf)) {
-            $xml->selectSingleNode($isChildOf)->appendChild($name, htmlspecialchars("$parsedValue"));
-        } else if (!empty($isAttributeOf)) {
-            $xml->selectSingleNode($isAttributeOf)->addAttribute($name, htmlspecialchars("$parsedValue"));
+            // Add as an attribute of the current node
+            $xml->addAttribute($name, $safeValue);
+        } elseif (!empty($isChildOf)) {
+            // Add as a child element of a specified node
+            $xml->selectSingleNode($isChildOf)->appendChild($name, $safeValue);
+        } elseif (!empty($isAttributeOf)) {
+            // Add as an attribute of a specified node
+            $xml->selectSingleNode($isAttributeOf)->addAttribute($name, $safeValue);
         } else {
-            $xml->appendChild($rootMetadata->getUsePrefix() . $name, htmlspecialchars("$parsedValue"));
+            // Add as a normal child element with optional namespace prefix
+            $xml->appendChild($rootMetadata->getUsePrefix() . $name, $safeValue);
         }
 
         return true;
     }
-
 }

--- a/src/File.php
+++ b/src/File.php
@@ -27,10 +27,10 @@ class File
     }
 
     /**
-     * @return string|bool
-     * @throws FileException
+     * @return string|false Returns file contents as string on success, false if reading fails
+     * @throws FileException when file does not exist
      */
-    public function getContents(): string|bool
+    public function getContents(): string|false
     {
         if (!file_exists($this->filename)) {
             throw new FileException('File not found');

--- a/src/File.php
+++ b/src/File.php
@@ -27,10 +27,10 @@ class File
     }
 
     /**
-     * @return string
+     * @return string|bool
      * @throws FileException
      */
-    public function getContents(): string
+    public function getContents(): string|bool
     {
         if (!file_exists($this->filename)) {
             throw new FileException('File not found');

--- a/src/XmlDocument.php
+++ b/src/XmlDocument.php
@@ -88,82 +88,108 @@ class XmlDocument extends XmlNode
     /**
      * Adjust xml string to the proper format
      *
-     * @param string|bool $string $string - XML string document
-     * @return string - Return the string converted
+     * @param string $string XML string document
+     * @return string Return the string converted
      * @throws XmlUtilException
      */
-    protected function fixXmlHeader(string|bool $string): string
+    protected function fixXmlHeader(string $string): string
     {
-        if ($string === false) {
-            throw new XmlUtilException("Error loading XML Document.", 250);
-        }
-
         $string = $this->removeBom($string);
 
-        if (str_contains($string, "<?xml")) {
-            $xmlTagEnd = strpos($string, "?>");
-            if ($xmlTagEnd !== false) {
-                $xmlTagEnd += 2;
-                $xmlHeader = substr($string, 0, $xmlTagEnd);
-
-                if ($xmlHeader == "<?xml?>") {
-                    $xmlHeader = "<?xml ?>";
-                }
-            } else {
-                throw new XmlUtilException("XML header bad formatted.", 251);
-            }
-
-            // Complete header elements
-            $count = 0;
-            $xmlHeader = preg_replace(
-                "/version=([\"'][\w\-.]+[\"'])/",
-                "version=\"".self::XML_VERSION."\"",
-                $xmlHeader,
-                1,
-                $count
-            );
-            if ($count == 0) {
-                $xmlHeader = substr($xmlHeader, 0, 6)."version=\"".self::XML_VERSION."\" ".substr($xmlHeader, 6);
-            }
-            $count = 0;
-            $xmlHeader = preg_replace(
-                "/encoding=([\"'][\w\-.]+[\"'])/",
-                "encoding=\"".self::XML_ENCODING."\"",
-                $xmlHeader,
-                1,
-                $count
-            );
-            if ($count == 0) {
-                $xmlHeader = substr($xmlHeader, 0, 6)."encoding=\"".self::XML_ENCODING."\" ".substr($xmlHeader, 6);
-            }
-
-            // Fix header position (first version, after encoding)
-            $xmlHeader = preg_replace(
-                "/<\?([\w\W]*)\s+(encoding=([\"'][\w\-.]+[\"']))\s+(version=([\"'][\w\-.]+[\"']))\s*\?>/",
-                "<?\\1 \\4 \\2?>",
-                $xmlHeader,
-                1,
-                $count
-            );
-
-            return $xmlHeader.substr($string, $xmlTagEnd);
-        } else {
-            $xmlHeader = '<?xml version="'.self::XML_VERSION.'" encoding="'.self::XML_ENCODING.'"?>';
-            return $xmlHeader.$string;
+        // If no XML declaration exists, add one
+        if (strncmp($string, '<?xml', 5) !== 0) {
+            return '<?xml version="' . self::XML_VERSION . '" encoding="' . self::XML_ENCODING . '"?>' . $string;
         }
+
+        // Find the end of XML declaration
+        $xmlTagEnd = strpos($string, "?>");
+        if ($xmlTagEnd === false) {
+            throw new XmlUtilException("XML header bad formatted.", 251);
+        }
+        $xmlTagEnd += 2;
+
+        // Extract header content
+        $xmlHeader = substr($string, 0, $xmlTagEnd);
+
+        // Handle empty XML declaration
+        if ($xmlHeader === '<?xml?>') {
+            return '<?xml version="' . self::XML_VERSION . '" encoding="' . self::XML_ENCODING . '"?>' . substr($string, $xmlTagEnd);
+        }
+
+        // Parse all attributes
+        $attributes = [];
+        $attributeOrder = [];
+        
+        // Match all attributes and their order, handling malformed declarations
+        if (preg_match_all('/(\w+)\s*=\s*(["\']?)([^"\'\s?>]+)\\2/', $xmlHeader, $matches, PREG_SET_ORDER)) {
+            foreach ($matches as $match) {
+                $name = $match[1];
+                $value = $match[3];
+                
+                if ($name === 'version') {
+                    // Only allow version 1.0 or 1.1
+                    $attributes[$name] = ($value === '1.0' || $value === '1.1') ? $value : self::XML_VERSION;
+                } elseif ($name === 'encoding') {
+                    // Normalize encoding value
+                    $value = strtolower($value);
+                    $attributes[$name] = ($value === 'utf8') ? 'utf-8' : $value;
+                } elseif ($name === 'standalone') {
+                    // Handle standalone attribute
+                    $value = strtolower($value);
+                    if ($value === 'yes' || $value === 'no') {
+                        $attributes[$name] = $value;
+                    }
+                }
+                
+                // Keep track of attribute order
+                $attributeOrder[] = $name;
+            }
+        }
+
+        // If no attributes were found in a malformed declaration, use defaults
+        if (empty($attributes)) {
+            return '<?xml version="' . self::XML_VERSION . '" encoding="' . self::XML_ENCODING . '"?>' . substr($string, $xmlTagEnd);
+        }
+
+        // Build the header preserving original attribute order
+        $headerParts = [];
+
+        // Always add version first
+        $headerParts[] = 'version="' . (isset($attributes['version']) ? $attributes['version'] : self::XML_VERSION) . '"';
+
+        // Add encoding if not present
+        if (!isset($attributes['encoding'])) {
+            $headerParts[] = 'encoding="' . self::XML_ENCODING . '"';
+        } else {
+            $headerParts[] = 'encoding="' . $attributes['encoding'] . '"';
+        }
+
+        // Add standalone if it was present in the original
+        if (isset($attributes['standalone'])) {
+            $headerParts[] = 'standalone="' . $attributes['standalone'] . '"';
+        }
+
+        $xmlHeader = '<?xml ' . implode(' ', $headerParts) . '?>';
+
+        return $xmlHeader . substr($string, $xmlTagEnd);
     }
 
-    protected function removeBom(string|bool $xmlStr): string|null
+    /**
+     * Remove BOM from XML string if present
+     *
+     * @param string $xmlStr XML string to process
+     * @return string Processed string without BOM
+     */
+    protected function removeBom(string $xmlStr): string
     {
-        if ($xmlStr === false) {
-            throw new XmlUtilException("Error loading XML Document.", 250);
-        }
-        return preg_replace('/^\xEF\xBB\xBF/', '', $xmlStr);
+        return str_starts_with($xmlStr, "\xEF\xBB\xBF") ? substr($xmlStr, 3) : $xmlStr;
     }
 
     /**
      *
      * @param string $filename
+     * @param bool $format
+     * @param bool $noHeader
      * @throws XmlUtilException
      */
     public function save(string $filename, bool $format = false, bool $noHeader = false): void

--- a/src/XmlDocument.php
+++ b/src/XmlDocument.php
@@ -88,12 +88,16 @@ class XmlDocument extends XmlNode
     /**
      * Adjust xml string to the proper format
      *
-     * @param string $string - XML string document
+     * @param string|bool $string $string - XML string document
      * @return string - Return the string converted
      * @throws XmlUtilException
      */
-    protected function fixXmlHeader(string $string): string
+    protected function fixXmlHeader(string|bool $string): string
     {
+        if ($string === false) {
+            throw new XmlUtilException("Error loading XML Document.", 250);
+        }
+
         $string = $this->removeBom($string);
 
         if (str_contains($string, "<?xml")) {
@@ -149,8 +153,11 @@ class XmlDocument extends XmlNode
         }
     }
 
-    protected function removeBom(string $xmlStr): string
+    protected function removeBom(string|bool $xmlStr): string|null
     {
+        if ($xmlStr === false) {
+            throw new XmlUtilException("Error loading XML Document.", 250);
+        }
         return preg_replace('/^\xEF\xBB\xBF/', '', $xmlStr);
     }
 

--- a/src/XmlNode.php
+++ b/src/XmlNode.php
@@ -261,7 +261,7 @@ class XmlNode
     }
 
 
-    public function toArray(Closure $func = null): array
+    public function toArray(?Closure $func = null): array
     {
         return $this->_toArray($this->DOMNode(), $func);
     }
@@ -380,7 +380,7 @@ class XmlNode
         return $this->_toString($this->DOMDocument(), $format, $this->node);
     }
 
-    protected function _toString(DOMDocument $domDocument, bool $format = false, DOMNode $node = null): string
+    protected function _toString(DOMDocument $domDocument, bool $format = false, ?DOMNode $node = null): string
     {
         if (!$format) {
             return $domDocument->saveXML($node);

--- a/tests/CleanDocumentTest.php
+++ b/tests/CleanDocumentTest.php
@@ -3,12 +3,14 @@
 namespace Tests;
 
 use ByJG\XmlUtil\CleanDocument;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class CleanDocumentTest extends TestCase
 {
     protected CleanDocument $object;
 
+    #[Override]
     public function setUp(): void
     {
         $this->object = new CleanDocument(

--- a/tests/XmlDocument/XmlDocumentArrayTest.php
+++ b/tests/XmlDocument/XmlDocumentArrayTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\File;
+use ByJG\XmlUtil\XmlDocument;
+use PHPUnit\Framework\TestCase;
+
+class XmlDocumentArrayTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testXml2Array1(): void
+    {
+        $file = new File(__DIR__ . '/../buggy.xml');
+        $xml = new XmlDocument($file, preserveWhiteSpace: false);
+
+        $array = $xml->toArray();
+        $this->assertEquals([ "node" => [ "subnode" => "value"]], $array);
+    }
+
+    public function testXml2Array2(): void
+    {
+        $xml = new XmlDocument('<root><node param="pval">value</node></root>');
+
+        $array = $xml->toArray();
+        $this->assertEquals([ "node" => "value"], $array);
+    }
+} 

--- a/tests/XmlDocument/XmlDocumentBasicTest.php
+++ b/tests/XmlDocument/XmlDocumentBasicTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\Exception\XmlUtilException;
+use ByJG\XmlUtil\File;
+use ByJG\XmlUtil\XmlDocument;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class XmlDocumentBasicTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testCreateXmlDocument(): void
+    {
+        $xml = new XmlDocument();
+        $this->assertEquals(self::XML_HEADER . "\n", $xml->toString());
+    }
+
+    public function testCreateXmlDocumentFromFile(): void
+    {
+        $file = new File(__DIR__ . '/../buggy.xml');
+        $xml = new XmlDocument($file, preserveWhiteSpace: false);
+        $this->assertEquals(self::XML_HEADER . "\n<root><node><subnode>value</subnode></node></root>\n", $xml->toString());
+    }
+
+    /**
+     * Data provider for XML declaration tests
+     *
+     * @return array
+     */
+    public static function xmlDeclarationProvider(): array
+    {
+        return [
+            'no declaration' => [
+                'input' => '<root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'empty declaration' => [
+                'input' => '<?xml?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'only version' => [
+                'input' => '<?xml version="1.0"?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'only encoding utf8' => [
+                'input' => '<?xml encoding="utf8"?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'only encoding ascii' => [
+                'input' => '<?xml encoding="ascii"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii"?>' . "\n<root/>\n"
+            ],
+            'invalid version' => [
+                'input' => '<?xml version="9.0"encoding="ascii"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii"?>' . "\n<root/>\n"
+            ],
+            'different attribute order' => [
+                'input' => '<?xml encoding="ascii" version="1.0"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii"?>' . "\n<root/>\n"
+            ],
+            'with standalone' => [
+                'input' => '<?xml version="1.0" encoding="ascii" standalone="yes"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii" standalone="yes"?>' . "\n<root/>\n"
+            ],
+            'with only standalone' => [
+                'input' => '<?xml standalone="yes"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="utf-8" standalone="yes"?>' . "\n<root/>\n"
+            ],
+            'with invalid attribute' => [
+                'input' => '<?xml abc="test"?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ]
+        ];
+    }
+
+    #[DataProvider('xmlDeclarationProvider')]
+    public function testCreateXmlDocumentFromStr(string $input, string $expected): void
+    {
+        $xml = new XmlDocument($input);
+        $this->assertEquals($expected, $xml->toString());
+    }
+
+    public function testCreateDocumentFromNode(): void
+    {
+        $file = new File(__DIR__ . '/../buggy.xml');
+        $xml = new XmlDocument($file, preserveWhiteSpace: false);
+
+        $node = $xml->selectSingleNode('//subnode');
+
+        $xmlFinal = new XmlDocument($node);
+        $this->assertEquals(self::XML_HEADER . "\n<subnode>value</subnode>\n", $xmlFinal->toString());
+    }
+
+    public function testCreateFailed(): void
+    {
+        $this->expectException(XmlUtilException::class);
+        $this->expectExceptionMessage('Error loading XML Document');
+        new XmlDocument('<a>1');
+    }
+
+    public function testGetFormattedDocument(): void
+    {
+        $file = new File(__DIR__ . '/../buggy.xml');
+        $xml = new XmlDocument($file);
+
+        $formatted = $xml->toString(true);
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n<root>\n  <node>\n    <subnode>value</subnode>\n  </node>\n</root>\n" , $formatted
+        );
+    }
+} 

--- a/tests/XmlDocument/XmlDocumentFileTest.php
+++ b/tests/XmlDocument/XmlDocumentFileTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\File;
+use ByJG\XmlUtil\XmlDocument;
+use PHPUnit\Framework\TestCase;
+
+class XmlDocumentFileTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testSaveXmlDocument(): void
+    {
+        $file = new File(__DIR__ . '/../buggy.xml');
+        $xml = new XmlDocument($file, preserveWhiteSpace: false);
+
+        $filename = sys_get_temp_dir() . '/save.xml';
+        if (file_exists($filename)) {
+            unlink($filename);
+        }
+
+        // Save without format
+        $this->assertFalse(file_exists($filename));
+        $xml->save($filename);
+        $this->assertTrue(file_exists($filename));
+        $contents = file_get_contents($filename);
+        $this->assertEquals(self::XML_HEADER . "\n<root><node><subnode>value</subnode></node></root>\n", $contents);
+        unlink($filename);
+
+        // Save with format
+        $this->assertFalse(file_exists($filename));
+        $xml->save($filename, true);
+        $this->assertTrue(file_exists($filename));
+        $contents = file_get_contents($filename);
+        $this->assertEquals(
+            self::XML_HEADER . "\n"
+            . "<root>\n"
+            . "  <node>\n"
+            . "    <subnode>value</subnode>\n"
+            . "  </node>\n"
+            . "</root>\n",
+            $contents);
+        unlink($filename);
+    }
+} 

--- a/tests/XmlDocument/XmlDocumentNamespaceTest.php
+++ b/tests/XmlDocument/XmlDocumentNamespaceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\Exception\XmlUtilException;
+use ByJG\XmlUtil\File;
+use ByJG\XmlUtil\XmlDocument;
+use PHPUnit\Framework\TestCase;
+
+class XmlDocumentNamespaceTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testSelectNodesNamespace(): void
+    {
+        $file = new File(__DIR__ . '/../feed-atom.txt');
+        $document = new XmlDocument($file);
+
+        $nodes = $document->selectNodes(
+            'ns:entry',
+            [
+                "ns" => "http://www.w3.org/2005/Atom"
+            ]
+        );
+
+        $this->assertEquals(25, $nodes->length);
+    }
+
+    public function testSelectNodesNamespaceError(): void
+    {
+        $file = new File(__DIR__ . '/../feed-atom.txt');
+        $document = new XmlDocument($file);
+
+        $this->expectException(XmlUtilException::class);
+        $this->expectExceptionMessage('Error selecting nodes');
+
+        $nodes = $document->selectNodes(
+            'ns:entry'
+        );
+    }
+
+    public function testSelectNodesNamespaceFromNewDoc(): void
+    {
+        $document = XmlDocument::emptyDocument("e:root", "http://example.com");
+        $document->appendChild("e:node", "value");
+
+        $nodes = $document->selectSingleNode("e:node", ["e" => "http://example.com"]);
+
+        $this->assertEquals("value", $nodes->DOMNode()->textContent);
+    }
+
+    public function testSelectNodesNamespaceFromNewDocError(): void
+    {
+        $document = XmlDocument::emptyDocument("e:root");
+        $document->appendChild("e:node", "value");
+
+        $this->expectException(XmlUtilException::class);
+        $this->expectExceptionMessage('Node not found');
+
+        $nodes = $document->selectSingleNode("e:node", ["e" => "http://example.com"]);
+
+        $this->assertEquals("value", $nodes->DOMNode()->textContent);
+    }
+
+    public function testAppendNewNode(): void
+    {
+        $document = XmlDocument::emptyDocument("e:root", "http://example.com");
+        $document->appendChild("f:node", "value", "http://example.com/2");
+
+        $nodes = $document->selectSingleNode("f:node", ["f" => "http://example.com/2"]);
+        $this->assertEquals("value", $nodes->DOMNode()->textContent);
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<e:root xmlns:e="http://example.com">'
+            . '<node xmlns="http://example.com/2">value</node>'
+            . '</e:root>'
+            . "\n",
+            $document->toString()
+        );
+    }
+
+    public function testAddNamespace(): void
+    {
+        $xmlStr = '<root/>';
+        $xml = new XmlDocument($xmlStr);
+        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
+
+        $xml->addNamespace('my', 'http://www.example.com/mytest/');
+        $this->assertEquals(self::XML_HEADER . "\n<root xmlns:my=\"http://www.example.com/mytest/\"/>\n", $xml->toString());
+
+        $xml->appendChild('my:othernodens', 'teste');
+        $this->assertEquals(self::XML_HEADER . "\n<root xmlns:my=\"http://www.example.com/mytest/\"><my:othernodens>teste</my:othernodens></root>\n", $xml->toString());
+
+        $xml->appendChild('nodens', 'teste', 'http://www.example.com/mytest/');
+        $this->assertEquals(self::XML_HEADER . "\n<root xmlns:my=\"http://www.example.com/mytest/\"><my:othernodens>teste</my:othernodens><my:nodens>teste</my:nodens></root>\n", $xml->toString());
+
+        $xml->appendChild('other', 'text', 'http://www.example.org/x/');
+        $this->assertEquals(self::XML_HEADER . "\n<root xmlns:my=\"http://www.example.com/mytest/\"><my:othernodens>teste</my:othernodens><my:nodens>teste</my:nodens><other xmlns=\"http://www.example.org/x/\">text</other></root>\n", $xml->toString());
+    }
+
+    public function testCreateXmlDocumentWithNamespace()
+    {
+        $xml = XmlDocument::emptyDocument('root');
+        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
+
+        $xml = XmlDocument::emptyDocument('p:root', 'http://example.com');
+        $this->assertEquals(self::XML_HEADER . "\n<p:root xmlns:p=\"http://example.com\"/>\n", $xml->toString());
+    }
+} 

--- a/tests/XmlDocument/XmlDocumentNodeTest.php
+++ b/tests/XmlDocument/XmlDocumentNodeTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\XmlDocument;
+use ByJG\XmlUtil\XmlNode;
+use PHPUnit\Framework\TestCase;
+
+class XmlDocumentNodeTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testCreateChild(): void
+    {
+        $dom = new XmlDocument('<root/>');
+        $node = $dom->appendChild('test1');
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test1/>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+
+        $node2 = $node->appendChild('test2', 'text2');
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test1>'
+            .   '<test2>text2</test2>'
+            . '</test1>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+
+        $node3 = $node->appendChild('test3', 'text3', 'http://opensource.byjg.com');
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test1>'
+            .   '<test2>text2</test2>'
+            .   '<test3 xmlns="http://opensource.byjg.com">text3</test3>'
+            . '</test1>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+
+        $node3->insertBefore('test1_2', 'text1-2');
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test1>'
+            .   '<test2>text2</test2>'
+            .   '<test1_2>text1-2</test1_2>'
+            .   '<test3 xmlns="http://opensource.byjg.com">text3</test3>'
+            . '</test1>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+
+        $node2->insertBefore('testBefore', 'textBefore');
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test1>'
+            .   '<testBefore>textBefore</testBefore>'
+            .   '<test2>text2</test2>'
+            .   '<test1_2>text1-2</test1_2>'
+            .   '<test3 xmlns="http://opensource.byjg.com">text3</test3>'
+            . '</test1>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+    }
+
+    public function testAddTextNode(): void
+    {
+        $dom = new XmlDocument('<root><subject></subject></root>');
+
+        $node = $dom->selectSingleNode('subject');
+        $node->addText('Text');
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<subject>'
+            .   'Text'
+            . '</subject>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+    }
+
+    public function testAddAttribute(): void
+    {
+        $dom = new XmlDocument('<root><subject>Text</subject></root>');
+
+        $node = $dom->selectSingleNode('subject');
+        $node->addAttribute('attr', 'value');
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<subject attr="value">'
+            .   'Text'
+            . '</subject>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+    }
+
+    public function testSelectNodes(): void
+    {
+        $dom = new XmlDocument('<root><a><item arg="1"/><item arg="2"><b1/><b2/></item><item arg="3"/></a></root>');
+
+        $nodeList = $dom->selectNodes('a/item');
+        $this->assertEquals(3, $nodeList->length);
+        $this->assertEquals('item', $nodeList->item(0)->nodeName);
+        $this->assertEquals('1', $nodeList->item(0)->attributes->getNamedItem('arg')->nodeValue);
+        $this->assertEquals('item', $nodeList->item(1)->nodeName);
+        $this->assertEquals('2', $nodeList->item(1)->attributes->getNamedItem('arg')->nodeValue);
+        $this->assertEquals('item', $nodeList->item(2)->nodeName);
+        $this->assertEquals('3', $nodeList->item(2)->attributes->getNamedItem('arg')->nodeValue);
+
+        $node = XmlNode::instance($nodeList->item(1))->selectSingleNode('b2');
+        $this->assertEquals('b2', $node->DOMNode()->nodeName);
+    }
+
+    public function testInnerText(): void
+    {
+        $dom = new XmlDocument('<root><a><item arg="1"/><item arg="2"><b1/><b2/></item><item arg="3"/></a></root>');
+
+        $node = $dom->selectSingleNode('a/item[@arg="2"]');
+
+        $text = $node->toString();
+        $this->assertEquals('<item arg="2"><b1/><b2/></item>', $text);
+
+        $text = $node->innerText();
+        $this->assertEquals("<b1/><b2/>", $text);
+    }
+
+    public function testRemoveNode(): void
+    {
+        $dom = new XmlDocument('<root><subject>Text</subject><a/><b/></root>');
+
+        $dom->selectSingleNode('subject')->removeNode();
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<a/>'
+            . '<b/>'
+            . '</root>'
+            . "\n",
+            $dom->toString()
+        );
+    }
+
+    public function testRenameNode()
+    {
+        $xml = new XmlDocument('<root><node>value</node></root>');
+
+        $node = $xml->selectSingleNode('node');
+        $node->renameNode('newnode');
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<newnode>value</newnode>'
+            . '</root>'
+            . "\n",
+            $xml->toString()
+        );
+    }
+
+    public function testRenameNodeComplex()
+    {
+        $xml = new XmlDocument('<root><node a="1">value<sub>test</sub><other id="2">foo</other></node></root>');
+
+        $node = $xml->selectSingleNode('node');
+        $node->renameNode('newnode');
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<newnode a="1">value<sub>test</sub><other id="2">foo</other></newnode>'
+            . '</root>'
+            . "\n",
+            $xml->toString()
+        );
+    }
+
+    public function testParentNode()
+    {
+        $xml = new XmlDocument('<root><node><subnode>a</subnode></node></root>');
+
+        $subNode = $xml->selectSingleNode('//subnode');
+        $this->assertEquals('subnode', $subNode->DOMNode()->nodeName);
+
+        $parentNode = $subNode->parentNode();
+        $this->assertEquals('node', $parentNode->DOMNode()->nodeName);
+
+        $rootNode = $parentNode->parentNode();
+        $this->assertEquals('root', $rootNode->DOMNode()->nodeName);
+
+        $this->assertNull($rootNode->parentNode());
+    }
+} 

--- a/tests/XmlDocument/XmlDocumentObjectTest.php
+++ b/tests/XmlDocument/XmlDocumentObjectTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\XmlDocument;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixture\ClassSample1;
+use Tests\Fixture\ClassSampleWithArrayElement;
+
+class XmlDocumentObjectTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testAppendObject(): void
+    {
+        $xmlStr = '<root/>';
+        $xml = new XmlDocument($xmlStr);
+
+        $xml->appendChild('test', 'value');
+        $node = $xml->appendChild('test2', 'value2');
+
+        $class = new ClassSample1();
+        $class->setName('John');
+        $class->setAge(30);
+        $class->setAddress((object)['street' => 'Main St', 'number' => 123]);
+
+        $node->appendObject($class);
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test>value</test>'
+            . '<test2>value2'
+            .   '<name>John</name>'
+            .   '<age>30</age>'
+            .   '<address>'
+            .     '<street>Main St</street>'
+            .     '<number>123</number>'
+            .   '</address>'
+            . '</test2>'
+            . '</root>'
+            . "\n",
+            $xml->toString()
+        );
+    }
+
+    public function testShouldAcceptPropertyIgnoreEmptyOnArray(): void
+    {
+        $xmlStr = '<root/>';
+        $xml = new XmlDocument($xmlStr);
+
+        $xml->appendChild('test', 'value');
+        $node = $xml->appendChild('test2', 'value2');
+
+        $class = new ClassSampleWithArrayElement();
+        $class->Name = 'John';
+        $class->age = 30;
+        $class->city = '';
+        $class->addresses = [];
+
+        $node->appendObject($class);
+
+        $this->assertEquals(
+            self::XML_HEADER . "\n" .
+            '<root>'
+            . '<test>value</test>'
+            . '<test2>value2'
+            .   '<name>John</name>'
+            .   '<age>30</age>'
+            . '</test2>'
+            . '</root>'
+            . "\n",
+            $xml->toString()
+        );
+    }
+} 

--- a/tests/XmlDocument/XmlDocumentValidationTest.php
+++ b/tests/XmlDocument/XmlDocumentValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\XmlDocument;
+
+use ByJG\XmlUtil\Exception\XmlUtilException;
+use ByJG\XmlUtil\XmlDocument;
+use PHPUnit\Framework\TestCase;
+
+class XmlDocumentValidationTest extends TestCase
+{
+    const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+
+    public function testValidateXmlError(): void
+    {
+        $this->expectException(XmlUtilException::class);
+        $this->expectExceptionMessage('XML Document is not valid according to');
+
+        $xml = new XmlDocument(
+            self::XML_HEADER . "\n" .
+            '<example>' .
+              '<child_string>This is an example.</child_string>' .
+              '<child_integer>Error condition.</child_integer>' .
+            '</example>'
+        );
+        $xml->validate(__DIR__ . '/../example.xsd');
+    }
+
+    public function testValidateXmlError2(): void
+    {
+        $xml = new XmlDocument(
+            self::XML_HEADER . "\n" .
+            '<example>' .
+              '<child_string>This is an example.</child_string>' .
+              '<child_integer>Error condition.</child_integer>' .
+            '</example>'
+        );
+
+        $result = $xml->validate(__DIR__ . '/../example.xsd', throwError: false);
+        $this->assertCount(1, $result);
+    }
+
+    public function testValidateXml(): void
+    {
+        $xml = new XmlDocument(
+            self::XML_HEADER . "\n" .
+            '<example>' .
+            '<child_string>This is an example.</child_string>' .
+            '<child_integer>10</child_integer>' .
+            '</example>'
+        );
+        $result = $xml->validate(__DIR__ . '/../example.xsd');
+        $this->assertNull($result);
+    }
+} 

--- a/tests/XmlUtilTest.php
+++ b/tests/XmlUtilTest.php
@@ -28,40 +28,62 @@ class XmlUtilTest extends TestCase
         $this->assertEquals(self::XML_HEADER . "\n<root><node><subnode>value</subnode></node></root>\n", $xml->toString());
     }
 
-    public function testCreateXmlDocumentFromStr(): void
+    /**
+     * Data provider for XML declaration tests
+     *
+     * @return array
+     */
+    public static function xmlDeclarationProvider(): array
     {
-        $xmlStr = '<root/>';
-        $xml = new XmlDocument($xmlStr);
-        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
+        return [
+            'no declaration' => [
+                'input' => '<root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'empty declaration' => [
+                'input' => '<?xml?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'only version' => [
+                'input' => '<?xml version="1.0"?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'only encoding utf8' => [
+                'input' => '<?xml encoding="utf8"?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ],
+            'only encoding ascii' => [
+                'input' => '<?xml encoding="ascii"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii"?>' . "\n<root/>\n"
+            ],
+            'invalid version' => [
+                'input' => '<?xml version="9.0"encoding="ascii"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii"?>' . "\n<root/>\n"
+            ],
+            'different attribute order' => [
+                'input' => '<?xml encoding="ascii" version="1.0"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii"?>' . "\n<root/>\n"
+            ],
+            'with standalone' => [
+                'input' => '<?xml version="1.0" encoding="ascii" standalone="yes"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="ascii" standalone="yes"?>' . "\n<root/>\n"
+            ],
+            'with only standalone' => [
+                'input' => '<?xml standalone="yes"?><root/>',
+                'expected' => '<?xml version="1.0" encoding="utf-8" standalone="yes"?>' . "\n<root/>\n"
+            ],
+            'with invalid attribute' => [
+                'input' => '<?xml abc="test"?><root/>',
+                'expected' => self::XML_HEADER . "\n<root/>\n"
+            ]
+        ];
     }
 
-    public function testCreateXmlDocumentFromStr2(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('xmlDeclarationProvider')]
+    public function testCreateXmlDocumentFromStr(string $input, string $expected): void
     {
-        $xmlStr = '<?xml?><root/>';
-        $xml = new XmlDocument($xmlStr);
-        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
-    }
-
-
-    public function testCreateXmlDocumentFromStr3(): void
-    {
-        $xmlStr = '<?xml version="1.0"?><root/>';
-        $xml = new XmlDocument($xmlStr);
-        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
-    }
-
-    public function testCreateXmlDocumentFromStr4(): void
-    {
-        $xmlStr = '<?xml encoding="utf8"?><root/>';
-        $xml = new XmlDocument($xmlStr);
-        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
-    }
-
-    public function testCreateXmlDocumentFromStr5(): void
-    {
-        $xmlStr = '<?xml encoding="ascii"?><root/>';
-        $xml = new XmlDocument($xmlStr);
-        $this->assertEquals(self::XML_HEADER . "\n<root/>\n", $xml->toString());
+        $xml = new XmlDocument($input);
+        $this->assertEquals($expected, $xml->toString());
     }
 
     public function testCreateDocumentFromNode(): void


### PR DESCRIPTION


## Major Changes

This PR introduces version 6.0 of the PHP XML Util library with several important improvements and breaking changes.

### New Features

1. Enhanced XML File Handling

- New dedicated File class API for reading and writing XML files
- Improved handling of file errors with more descriptive exceptions
- Added clear examples for file operations in documentation

2. XML Schema Validation

- New validation capabilities for XML documents against XSD schemas
- Support for both exception-based validation and error collection
- Comprehensive documentation with examples

3. Improved EntityParser

- Refactored with better code organization and documentation
- Added support for anonymous classes in XML serialization
- Enhanced error handling for invalid XML data
- More consistent type handling

4. More Flexible Type Handling

- Updated signature of key methods to handle nullable parameters appropriately
- Better null-safety throughout the codebase

5. Modern PHP Support

- Added support for PHP 8.4

### Breaking Changes

1. Dependency Updates

- Major: Updated requirement for byjg/serializer from ^5.0 to ^6.0
- Updated PHPUnit from ^9.6 to ^10.5|^11.5
- Updated Psalm from ^5.20 to ^5.9|^6.2

2. Method Signature Changes

- Several method signatures have been updated with union types:

    - File::getContents(): Return type changed from string to string|bool
   - XmlDocument::fixXmlHeader(): Parameter type changed from string to string|bool
   - XmlDocument::removeBom(): Parameter and return types updated
   - XmlNode::toArray(): Parameter type updated to use nullable syntax
   - XmlNode::_toString(): Parameter type updated to use nullable syntax
   - EntityParser::arrayToXml(): Parameter type updated to use nullable syntax

3. Error Handling

- More strict error checking and exception throwing for invalid XML content
- Changed error handling approach in several methods

## Compatibility Notes

- Requires PHP 8.1 or higher (now supports up to PHP 8.4)
- Projects using byjg/serializer 5.x must upgrade to 6.x
- Code that depends on specific parameter types or return types may need updates
- Applications relying on the previous error handling behavior may need adjustments

This update focuses on modernizing the library with the latest PHP features while improving code quality, maintainability, and adding new functionality for XML handling and validation.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Update the PHP XML Util library to version 6.0, adding support for PHP 8.4, enhancing documentation, and improving the API for better XML document manipulation, querying, and validation.

### Why are these changes being made?
These updates introduce new features such as powerful XPath querying, enhanced documentation with clear examples and API usage, improved error handling for file operations, support for PHP 8.4, and additional flexibility in XML entity and property handling. The improvements aim to make XML operations in PHP both easier and more intuitive with a more comprehensive feature set and a user-friendly API.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->